### PR TITLE
Change to git-docs directory after cloning

### DIFF
--- a/manuscript/QUICKSTART.md
+++ b/manuscript/QUICKSTART.md
@@ -44,6 +44,12 @@ git clone https://github.com/martyychang/git-docs.git
 ```
 
 This will create a directory named "git-docs" in your current directory.
+To perform Git operations in our git-docs project, you now need to
+drill into this new directory.
+
+```sh
+cd git-docs
+```
 
 ### Figure out your integration branch
 


### PR DESCRIPTION
Three out of three people walking through the quick start for the first time encountered the stumbling block below when trying to do something useful in Git after cloning the repository.

> fatal: Not a git repository (or any of the parent directories): .git

This pr explicitly adds an instruction for executing `cd git-docs` after cloning, so that the user's CLI session is now correctly situated in the project repository's directory.

